### PR TITLE
Accessibility labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
             </button>
         </div>
     </div>
-    <main>
     <div id="main-area">
         <div id="work-area">
             <div id="img-area">
@@ -92,7 +91,7 @@
         </div>
         <div id="description-wrapper" class="bordered-area search-width">
             <div id="not-found-display">
-                <img src="images/nothing-found.svg" alt="Nothing found" class="text-color-svg" width="90" height="110">
+                <img src="images/nothing-found.svg" alt="Nothing found" class="text-color-svg" width="90" height="110" aria-hidden="true">
                 <div id="not-found-text">No Descriptions Found</div>
             </div>
             <div id="descriptions"></div>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
             </button>
         </div>
     </div>
+    <main>
     <div id="main-area">
         <div id="work-area">
             <div id="img-area">
@@ -83,8 +84,6 @@
             </div>
             <div id="in-flight-wrapper" class="bordered-area">
                 <div id="add-in-flight" class="column-emoji-controls">
-                    <button id="add-in-flight-btn" class="page-button emoji-button large-emoji" onclick="addBlankInFlight()" aria-label="Add Chunk">➕
-                    </button>
                 </div>
                 <div id="in-flight"></div>
                 <div id="in-flight-controls" class="column-emoji-controls">
@@ -102,6 +101,7 @@
             <div id="descriptions"></div>
         </div>
     </div>
+    </main>
 </div>
 <div id="exec-wrapper" class="openable"></div>
 <div id="overlay" class="openable" onclick="hideEscapable()"></div>

--- a/index.html
+++ b/index.html
@@ -87,9 +87,6 @@
                 </div>
                 <div id="in-flight"></div>
                 <div id="in-flight-controls" class="column-emoji-controls">
-                    <button id="save-in-flight" class="page-button emoji-button large-emoji" onclick="saveAllInFlight()"
-                            title="Save All" aria-label="Save All">💾
-                    </button>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -83,13 +83,13 @@
             </div>
             <div id="in-flight-wrapper" class="bordered-area">
                 <div id="add-in-flight" class="column-emoji-controls">
-                    <button id="add-in-flight-btn" class="page-button emoji-button large-emoji" onclick="addBlankInFlight()">➕
+                    <button id="add-in-flight-btn" class="page-button emoji-button large-emoji" onclick="addBlankInFlight()" aria-label="Add Chunk">➕
                     </button>
                 </div>
                 <div id="in-flight"></div>
                 <div id="in-flight-controls" class="column-emoji-controls">
                     <button id="save-in-flight" class="page-button emoji-button large-emoji" onclick="saveAllInFlight()"
-                            title="Save All">💾
+                            title="Save All" aria-label="Save All">💾
                     </button>
                 </div>
             </div>

--- a/src/core.js
+++ b/src/core.js
@@ -260,3 +260,14 @@ function addDots() {
     })
 }
 
+function addButtons () {
+	let addBtn = document.createElement("button");
+	addBtn.classList.add("page-button", "emoji-button", "large-emoji");
+	addBtn.ariaLabel = getLocalized("addInFlightBtnTxt");
+	addBtn.textContent = "+";
+	addBtn.addEventListener("click", addBlankInFlight);
+	
+	const addInFlightContainer = document.getElementById("add-in-flight");
+	addInFlightContainer.appendChild(addBtn);
+}
+

--- a/src/core.js
+++ b/src/core.js
@@ -261,13 +261,21 @@ function addDots() {
 }
 
 function addButtons () {
-	let addBtn = document.createElement("button");
-	addBtn.classList.add("page-button", "emoji-button", "large-emoji");
-	addBtn.ariaLabel = getLocalized("addInFlightBtnTxt");
-	addBtn.textContent = "+";
-	addBtn.addEventListener("click", addBlankInFlight);
-	
-	const addInFlightContainer = document.getElementById("add-in-flight");
-	addInFlightContainer.appendChild(addBtn);
+    let addBtn = document.createElement("button");
+    addBtn.classList.add("page-button", "emoji-button", "large-emoji");
+    addBtn.ariaLabel = getLocalized("addInFlightBtnTxt");
+    addBtn.textContent = "+";
+    addBtn.addEventListener("click", addBlankInFlight);
+
+    let saveBtn = document.createElement("button");
+    saveBtn.classList.add("page-button", "emoji-button", "large-emoji");
+    saveBtn.ariaLabel = getLocalized("saveInFlightBtnTxt");
+    saveBtn.textContent = "💾";
+    saveBtn.addEventListener("click", saveAllInFlight);
+
+    const addInFlightContainer = document.getElementById("add-in-flight");
+    const inFlightControlsContainer = document.getElementById("in-flight-controls");
+    addInFlightContainer.appendChild(addBtn);
+    inFlightControlsContainer.appendChild(saveBtn);
 }
 

--- a/src/i18n-data.js
+++ b/src/i18n-data.js
@@ -17,6 +17,7 @@ MyAltTextOrg.i18n.pageText = {
         extractionLangSearchLbl: 'Text&nbsp;Extraction&nbsp;Language',
         extractBtnTxt: 'Extract',
         additionalImageTag: "Alt Text Continued",
+        addInFlightBtnTxt: "Add Chunk",
         addTranslationTxt: "Add&nbsp;Translation",
         searchPrompt: "Search Your Archive",
         maxLenTxt: "Max Length",

--- a/src/i18n-data.js
+++ b/src/i18n-data.js
@@ -18,6 +18,7 @@ MyAltTextOrg.i18n.pageText = {
         extractBtnTxt: 'Extract',
         additionalImageTag: "Alt Text Continued",
         addInFlightBtnTxt: "Add Chunk",
+        saveInFlightBtnTxt: "Save All",
         addTranslationTxt: "Add&nbsp;Translation",
         searchPrompt: "Search Your Archive",
         maxLenTxt: "Max Length",

--- a/src/last.js
+++ b/src/last.js
@@ -10,7 +10,8 @@
     updateDescriptionDisplay()
     hashIndexDescriptions()
     addDots()
-
+    addButtons()
+    
     const splashSeen = parseInt(window.localStorage.getItem("user.splash_seen") || "0")
     if (splashSeen < CURRENT_SPLASH) {
         showSplash()


### PR DESCRIPTION
* Updates ARIA labels for two emoji buttons, the in-flight add (+) and in-flight save all (💾) controls. To make the labels translatable, also add these controls to the existing localization system. For cleaner page code, they are now created on the page in core code, (`core.addButtons()`) which is called from last.js.
* Hides the "nothing found" icon from screen readers, to avoid duplicate labels.