### PR TITLE
fix: make dropdown font consistent

### DIFF
--- a/style/dropdowns.css
+++ b/style/dropdowns.css
@@ -65,7 +65,7 @@
 }
 
 .submenu-button {
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     font-weight: 900;
     color: var(--text);
     font-family: "Atkinson Hyperlegible", sans-serif;


### PR DESCRIPTION
This PR will make the submenu buttons' font the same size as the rest.