### PR TITLE
Change footer link to www.alt-text.org

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -234,7 +234,7 @@ function addDots() {
     const footer = document.createElement("div")
     footer.classList.add("links")
     footer.innerHTML = `
-                <a href="https://alt-text.org" target="_blank"><img class="link-logo" src="images/alt-text-org.svg"
+                <a href="https://www.alt-text.org" target="_blank"><img class="link-logo" src="images/alt-text-org.svg"
                                                                     alt="Alt-Text.org"></a>
                 <a href="https://github.com/alt-text-org/my.alt-text.org" target="_blank"><img class="link-logo"
                                                                                                src="images/github.svg"


### PR DESCRIPTION
At the time of this commit, the domain alt-text.org (without "www") does not resolve to an IP address.